### PR TITLE
Fix: automatically generate entity IDs in backend instead of receiving them from client

### DIFF
--- a/backend/config/database.go
+++ b/backend/config/database.go
@@ -57,8 +57,8 @@ func createTables(db *sql.DB) {
 
 	intervalsTable := `
 	CREATE TABLE IF NOT EXISTS intervals (
-		id SERIAL PRIMARY KEY,
-		activity_id INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+		id UUID PRIMARY KEY,
+		activity_id UUID NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
 		start_time TIMESTAMP NOT NULL,
 		duration BIGINT NOT NULL,
 		distance FLOAT NOT NULL,

--- a/backend/config/database.go
+++ b/backend/config/database.go
@@ -44,7 +44,7 @@ func createTables(db *sql.DB) {
 
 	activitiesTable := `
 	CREATE TABLE IF NOT EXISTS activities (
-		id SERIAL PRIMARY KEY,
+		id UUID PRIMARY KEY,
 		user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 		start TIMESTAMP NOT NULL,
 		duration BIGINT NOT NULL,

--- a/backend/config/database.go
+++ b/backend/config/database.go
@@ -35,7 +35,7 @@ func SetupDatabase() *sql.DB {
 func createTables(db *sql.DB) {
 	userTable := `
 	CREATE TABLE IF NOT EXISTS users (
-		id SERIAL PRIMARY KEY,
+		id UUID PRIMARY KEY,
 		name TEXT NOT NULL,
 		email TEXT UNIQUE NOT NULL,
 		city TEXT NOT NULL,
@@ -45,7 +45,7 @@ func createTables(db *sql.DB) {
 	activitiesTable := `
 	CREATE TABLE IF NOT EXISTS activities (
 		id SERIAL PRIMARY KEY,
-		user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 		start TIMESTAMP NOT NULL,
 		duration BIGINT NOT NULL,
 		distance FLOAT NOT NULL,

--- a/backend/internal/app/interval_service_test.go
+++ b/backend/internal/app/interval_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/liviaruegger/MAC0350/backend/internal/domain"
 )
 
@@ -41,8 +42,8 @@ func TestCreateInterval(t *testing.T) {
 				return nil
 			},
 			interval: domain.Interval{
-				ID:         1,
-				ActivityID: 1,
+				ID:         uuid.New(),
+				ActivityID: uuid.New(),
 				StartTime:  time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC),
 				Duration:   domain.DurationString((30 * time.Minute).String()),
 				Distance:   1000,
@@ -57,7 +58,10 @@ func TestCreateInterval(t *testing.T) {
 			createFunc: func(interval domain.Interval) error {
 				return errors.New("repo error")
 			},
-			interval:    domain.Interval{},
+			interval: domain.Interval{
+				ID:         uuid.New(),
+				ActivityID: uuid.New(),
+			},
 			expectedErr: errors.New("repo error"),
 		},
 	}

--- a/backend/internal/app/user_service.go
+++ b/backend/internal/app/user_service.go
@@ -3,15 +3,17 @@ package app
 import (
 	"github.com/liviaruegger/MAC0350/backend/internal/domain"
 	"github.com/liviaruegger/MAC0350/backend/internal/repository"
+
+	"github.com/google/uuid"
 )
 
 type UserService interface {
 	CreateUser(user domain.User) error
 	GetAllUsers() ([]domain.User, error)
-	GetUserByID(id int) (domain.User, error)
+	GetUserByID(id uuid.UUID) (domain.User, error)
 	GetUserByEmail(email string) (domain.User, error)
 	UpdateUser(user domain.User) error
-	DeleteUser(id int) error
+	DeleteUser(id uuid.UUID) error
 }
 
 // UserService provides user-related operations
@@ -32,7 +34,7 @@ func (s *userService) GetAllUsers() ([]domain.User, error) {
 	return s.repo.GetAllUsers()
 }
 
-func (s *userService) GetUserByID(id int) (domain.User, error) {
+func (s *userService) GetUserByID(id uuid.UUID) (domain.User, error) {
 	return s.repo.GetUserByID(id)
 }
 
@@ -44,6 +46,6 @@ func (s *userService) UpdateUser(user domain.User) error {
 	return s.repo.UpdateUser(user)
 }
 
-func (s *userService) DeleteUser(id int) error {
+func (s *userService) DeleteUser(id uuid.UUID) error {
 	return s.repo.DeleteUser(id)
 }

--- a/backend/internal/domain/activity.go
+++ b/backend/internal/domain/activity.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // LocationType defines the kind of environment for the swim
@@ -16,9 +18,10 @@ const (
 
 // Activity represents a full swim session
 type Activity struct {
-	ID uint `json:"id"`
-	// UserID is the ID of the user who performed the activity
-	UserID uint `json:"user_id"`
+	// ID is the unique identifier for the activity (PK)
+	ID uuid.UUID `json:"id"`
+	// UserID is the ID of the user who performed the activity (FK)
+	UserID uuid.UUID `json:"user_id"`
 	// Start time of the activity
 	Start time.Time `json:"start"`
 	// Duration of the activity in string format, e.g., "1h30m"

--- a/backend/internal/domain/interval.go
+++ b/backend/internal/domain/interval.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // IntervalType defines the kind of interval (e.g., swim, rest, drill)
@@ -49,9 +51,9 @@ const (
 
 // Interval represents a single segment of a swim session
 type Interval struct {
-	ID uint `json:"id"`
+	ID uuid.UUID `json:"id"`
 	// Foreign key to the swim activity/session
-	ActivityID uint `json:"activity_id"`
+	ActivityID uuid.UUID `json:"activity_id"`
 	// Start time of the interval
 	StartTime time.Time `json:"start_time"`
 	// Duration of the interval in string format, e.g., "1h30m"

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -1,9 +1,13 @@
 package domain
 
+import (
+	"github.com/google/uuid"
+)
+
 type User struct {
-	ID    uint   `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
-	City  string `json:"city"`
-	Phone string `json:"phone"`
+	ID    uuid.UUID `json:"id"`
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
+	City  string    `json:"city"`
+	Phone string    `json:"phone"`
 }

--- a/backend/internal/handler/input.go
+++ b/backend/internal/handler/input.go
@@ -1,9 +1,34 @@
 package handler
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/liviaruegger/MAC0350/backend/internal/domain"
+)
+
 // CreateUserRequest represents the request body for creating a new user
 type CreateUserRequest struct {
 	Name  string `json:"name" binding:"required"`
 	Email string `json:"email" binding:"required,email"`
 	City  string `json:"city" binding:"required"`
 	Phone string `json:"phone" binding:"required"`
+}
+
+// CreateIntervalRequest representa o corpo esperado para criar um intervalo (sem ID)
+type CreateIntervalRequest struct {
+	// ActivityID is the ID of the associated activity/session
+	ActivityID uuid.UUID `json:"activity_id" binding:"required"`
+	// StartTime is the start time of the interval
+	StartTime time.Time `json:"start_time" binding:"required"`
+	// Duration of the interval in string format, e.g., "1h30m"
+	Duration domain.DurationString `json:"duration" binding:"required"`
+	// Distance in meters
+	Distance float64 `json:"distance" binding:"required"`
+	// Type is one of the predefined interval types like "swim", "rest", etc.
+	Type domain.IntervalType `json:"type" binding:"required"`
+	// Stroke is the swimming stroke type like "freestyle", "backstroke", etc.
+	Stroke domain.StrokeType `json:"stroke" binding:"required"`
+	// Notes are optional remarks such as "felt strong", "used fins"
+	Notes string `json:"notes"`
 }

--- a/backend/internal/handler/input.go
+++ b/backend/internal/handler/input.go
@@ -15,7 +15,7 @@ type CreateUserRequest struct {
 	Phone string `json:"phone" binding:"required"`
 }
 
-// CreateIntervalRequest representa o corpo esperado para criar um intervalo (sem ID)
+// CreateIntervalRequest represents the request body for creating a new interval
 type CreateIntervalRequest struct {
 	// ActivityID is the ID of the associated activity/session
 	ActivityID uuid.UUID `json:"activity_id" binding:"required"`

--- a/backend/internal/handler/input.go
+++ b/backend/internal/handler/input.go
@@ -1,0 +1,9 @@
+package handler
+
+// CreateUserRequest represents the request body for creating a new user
+type CreateUserRequest struct {
+	Name  string `json:"name" binding:"required"`
+	Email string `json:"email" binding:"required,email"`
+	City  string `json:"city" binding:"required"`
+	Phone string `json:"phone" binding:"required"`
+}

--- a/backend/internal/handler/interval_handler.go
+++ b/backend/internal/handler/interval_handler.go
@@ -23,21 +23,32 @@ func NewIntervalHandler(s app.IntervalService) *IntervalHandler {
 // @Tags intervals
 // @Accept json
 // @Produce json
-// @Param interval body domain.Interval true "Interval data"
+// @Param interval body handler.CreateIntervalRequest true "Interval data"
 // @Success 201 {object} domain.Interval "Interval successfully created"
 // @Failure 400 {object} ErrorResponse "Invalid input"
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /intervals [post]
 func (h *IntervalHandler) CreateInterval(c *gin.Context) {
-	var newInterval domain.Interval
-	if err := c.BindJSON(&newInterval); err != nil {
+	var req CreateIntervalRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid JSON or missing required fields"})
 		return
 	}
 
-	if err := h.service.CreateInterval(newInterval); err != nil {
-		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "Service error"})
+	interval := domain.Interval{
+		ActivityID: req.ActivityID,
+		StartTime:  req.StartTime,
+		Duration:   req.Duration,
+		Distance:   req.Distance,
+		Type:       req.Type,
+		Stroke:     req.Stroke,
+		Notes:      req.Notes,
+	}
+
+	if err := h.service.CreateInterval(interval); err != nil {
+		c.IndentedJSON(http.StatusInternalServerError, ErrorResponse{Error: "Service error"})
 		return
 	}
 
-	c.IndentedJSON(http.StatusCreated, newInterval)
+	c.IndentedJSON(http.StatusCreated, interval)
 }

--- a/backend/internal/repository/interval_repository.go
+++ b/backend/internal/repository/interval_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"database/sql"
 
+	"github.com/google/uuid"
 	"github.com/liviaruegger/MAC0350/backend/internal/domain"
 )
 
@@ -11,7 +12,7 @@ type IntervalRepository interface {
 	Create(interval domain.Interval) error
 }
 
-// PostgresInvervalRepository is a concrete implementation of IntervalRepository using PostgreSQL
+// PostgresIntervalRepository is a concrete implementation of IntervalRepository using PostgreSQL
 type PostgresIntervalRepository struct {
 	db *sql.DB
 }
@@ -22,14 +23,17 @@ func NewIntervalRepository(db *sql.DB) *PostgresIntervalRepository {
 }
 
 func (r *PostgresIntervalRepository) Create(interval domain.Interval) error {
+	intervalID := uuid.New()
+
 	_, err := r.db.Exec(`
 		INSERT INTO intervals (
-			activity_id, start_time, duration, distance, type, stroke, notes
-		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+			id, activity_id, start_time, duration, distance, type, stroke, notes
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`,
+		intervalID,
 		interval.ActivityID,
 		interval.StartTime,
-		int64(interval.Duration.Seconds()), // store duration in seconds
+		int64(interval.Duration.Seconds()),
 		interval.Distance,
 		string(interval.Type),
 		string(interval.Stroke),

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -4,16 +4,18 @@ import (
 	"database/sql"
 
 	"github.com/liviaruegger/MAC0350/backend/internal/domain"
+
+	"github.com/google/uuid"
 )
 
 // UserRepository defines the interface for the user repository
 type UserRepository interface {
 	CreateUser(user domain.User) error
 	GetAllUsers() ([]domain.User, error)
-	GetUserByID(id int) (domain.User, error)
+	GetUserByID(id uuid.UUID) (domain.User, error)
 	GetUserByEmail(email string) (domain.User, error)
 	UpdateUser(user domain.User) error
-	DeleteUser(id int) error
+	DeleteUser(id uuid.UUID) error
 }
 
 // PostgresUserRepository is a concrete implementation of UserRepository using a PostgreSQL database connection
@@ -28,8 +30,8 @@ func NewUserRepository(db *sql.DB) *PostgresUserRepository {
 
 func (r *PostgresUserRepository) CreateUser(user domain.User) error {
 	_, err := r.db.Exec(
-		"INSERT INTO users (name, email, city, phone) VALUES ($1, $2, $3, $4)",
-		user.Name, user.Email, user.City, user.Phone,
+		"INSERT INTO users (id, name, email, city, phone) VALUES ($1, $2, $3, $4, $5)",
+		user.ID, user.Name, user.Email, user.City, user.Phone,
 	)
 	return err
 }
@@ -57,7 +59,7 @@ func (r *PostgresUserRepository) GetAllUsers() ([]domain.User, error) {
 	return users, nil
 }
 
-func (r *PostgresUserRepository) GetUserByID(id int) (domain.User, error) {
+func (r *PostgresUserRepository) GetUserByID(id uuid.UUID) (domain.User, error) {
 	var user domain.User
 	row := r.db.QueryRow("SELECT id, name, email, city, phone FROM users WHERE id = $1", id)
 	err := row.Scan(&user.ID, &user.Name, &user.Email, &user.City, &user.Phone)
@@ -82,7 +84,7 @@ func (r *PostgresUserRepository) UpdateUser(user domain.User) error {
 	return err
 }
 
-func (r *PostgresUserRepository) DeleteUser(id int) error {
+func (r *PostgresUserRepository) DeleteUser(id uuid.UUID) error {
 	_, err := r.db.Exec("DELETE FROM users WHERE id = $1", id)
 	return err
 }

--- a/backend/internal/repository/user_repository_test.go
+++ b/backend/internal/repository/user_repository_test.go
@@ -6,6 +6,8 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/liviaruegger/MAC0350/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/google/uuid"
 )
 
 func TestCreateUser(t *testing.T) {
@@ -38,16 +40,20 @@ func TestGetAllUsers(t *testing.T) {
 
 	repo := NewUserRepository(db)
 
+	// Use github.com/google/uuid for UUIDs
+	id1 := uuid.New()
+	id2 := uuid.New()
+
 	expectedUsers := []domain.User{
 		{
-			ID:    1,
+			ID:    id1,
 			Name:  "John Doe",
 			Email: "john.doe@example.com",
 			City:  "São Paulo",
 			Phone: "+5511999999999",
 		},
 		{
-			ID:    2,
+			ID:    id2,
 			Name:  "Jane Doe",
 			Email: "jane.doe@example.com",
 			City:  "Rio de Janeiro",
@@ -56,8 +62,8 @@ func TestGetAllUsers(t *testing.T) {
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "name", "email", "city", "phone"}).
-		AddRow(expectedUsers[0].ID, expectedUsers[0].Name, expectedUsers[0].Email, expectedUsers[0].City, expectedUsers[0].Phone).
-		AddRow(expectedUsers[1].ID, expectedUsers[1].Name, expectedUsers[1].Email, expectedUsers[1].City, expectedUsers[1].Phone)
+		AddRow(expectedUsers[0].ID.String(), expectedUsers[0].Name, expectedUsers[0].Email, expectedUsers[0].City, expectedUsers[0].Phone).
+		AddRow(expectedUsers[1].ID.String(), expectedUsers[1].Name, expectedUsers[1].Email, expectedUsers[1].City, expectedUsers[1].Phone)
 
 	mock.ExpectQuery("SELECT id, name, email, city, phone FROM users").
 		WillReturnRows(rows)
@@ -132,8 +138,9 @@ func TestGetUserByID(t *testing.T) {
 
 	repo := NewUserRepository(db)
 
+	id := uuid.New()
 	expectedUser := domain.User{
-		ID:    1,
+		ID:    id,
 		Name:  "John Doe",
 		Email: "john.doe@example.com",
 		City:  "São Paulo",
@@ -141,13 +148,13 @@ func TestGetUserByID(t *testing.T) {
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "name", "email", "city", "phone"}).
-		AddRow(expectedUser.ID, expectedUser.Name, expectedUser.Email, expectedUser.City, expectedUser.Phone)
+		AddRow(expectedUser.ID.String(), expectedUser.Name, expectedUser.Email, expectedUser.City, expectedUser.Phone)
 
 	mock.ExpectQuery("SELECT id, name, email, city, phone FROM users WHERE id = \\$1").
-		WithArgs(expectedUser.ID).
+		WithArgs(expectedUser.ID.String()).
 		WillReturnRows(rows)
 
-	user, err := repo.GetUserByID(int(expectedUser.ID))
+	user, err := repo.GetUserByID(expectedUser.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedUser, user)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -160,8 +167,9 @@ func TestGetUserByEmail(t *testing.T) {
 
 	repo := NewUserRepository(db)
 
+	id := uuid.New()
 	expectedUser := domain.User{
-		ID:    1,
+		ID:    id,
 		Name:  "John Doe",
 		Email: "john.doe@example.com",
 		City:  "São Paulo",
@@ -169,7 +177,7 @@ func TestGetUserByEmail(t *testing.T) {
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "name", "email", "city", "phone"}).
-		AddRow(expectedUser.ID, expectedUser.Name, expectedUser.Email, expectedUser.City, expectedUser.Phone)
+		AddRow(expectedUser.ID.String(), expectedUser.Name, expectedUser.Email, expectedUser.City, expectedUser.Phone)
 
 	mock.ExpectQuery("SELECT id, name, email, city, phone FROM users WHERE email = \\$1").
 		WithArgs(expectedUser.Email).
@@ -205,8 +213,9 @@ func TestUpdateUser(t *testing.T) {
 
 	repo := NewUserRepository(db)
 
+	userID := uuid.New()
 	user := domain.User{
-		ID:    1,
+		ID:    userID,
 		Name:  "John Updated",
 		Email: "john.updated@example.com",
 		City:  "Campinas",
@@ -214,7 +223,7 @@ func TestUpdateUser(t *testing.T) {
 	}
 
 	mock.ExpectExec("UPDATE users SET name = \\$1, email = \\$2, city = \\$3, phone = \\$4 WHERE id = \\$5").
-		WithArgs(user.Name, user.Email, user.City, user.Phone, user.ID).
+		WithArgs(user.Name, user.Email, user.City, user.Phone, user.ID.String()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = repo.UpdateUser(user)
@@ -229,10 +238,10 @@ func TestDeleteUser(t *testing.T) {
 
 	repo := NewUserRepository(db)
 
-	userID := 1
+	userID := uuid.New()
 
 	mock.ExpectExec("DELETE FROM users WHERE id = \\$1").
-		WithArgs(userID).
+		WithArgs(userID.String()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = repo.DeleteUser(userID)

--- a/backend/internal/repository/user_repository_test.go
+++ b/backend/internal/repository/user_repository_test.go
@@ -18,6 +18,7 @@ func TestCreateUser(t *testing.T) {
 	repo := NewUserRepository(db)
 
 	user := domain.User{
+		ID:    uuid.New(),
 		Name:  "John Doe",
 		Email: "john.doe@example.com",
 		City:  "São Paulo",
@@ -25,7 +26,7 @@ func TestCreateUser(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO users").
-		WithArgs(user.Name, user.Email, user.City, user.Phone).
+		WithArgs(user.ID.String(), user.Name, user.Email, user.City, user.Phone).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = repo.CreateUser(user)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -111,7 +111,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/domain.User"
+                            "$ref": "#/definitions/handler.CreateUserRequest"
                         }
                     }
                 ],
@@ -196,8 +196,8 @@ const docTemplate = `{
                 "summary": "Get user by ID",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -238,8 +238,8 @@ const docTemplate = `{
                 "summary": "Update an existing user",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -295,8 +295,8 @@ const docTemplate = `{
                 "summary": "Delete a user",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -425,7 +425,30 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
-                    "type": "integer"
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.CreateUserRequest": {
+            "type": "object",
+            "required": [
+                "city",
+                "email",
+                "name",
+                "phone"
+            ],
+            "properties": {
+                "city": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -35,7 +35,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/domain.Interval"
+                            "$ref": "#/definitions/handler.CreateIntervalRequest"
                         }
                     }
                 ],
@@ -334,7 +334,7 @@ const docTemplate = `{
             "properties": {
                 "activity_id": {
                     "description": "Foreign key to the swim activity/session",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "distance": {
                     "description": "Distance in meters",
@@ -345,7 +345,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "notes": {
                     "description": "Optional notes like \"felt strong\", \"used fins\"",
@@ -432,6 +432,55 @@ const docTemplate = `{
                 },
                 "phone": {
                     "type": "string"
+                }
+            }
+        },
+        "handler.CreateIntervalRequest": {
+            "type": "object",
+            "required": [
+                "activity_id",
+                "distance",
+                "duration",
+                "start_time",
+                "stroke",
+                "type"
+            ],
+            "properties": {
+                "activity_id": {
+                    "description": "ActivityID is the ID of the associated activity/session",
+                    "type": "string"
+                },
+                "distance": {
+                    "description": "Distance in meters",
+                    "type": "number"
+                },
+                "duration": {
+                    "description": "Duration of the interval in string format, e.g., \"1h30m\"",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Notes are optional remarks such as \"felt strong\", \"used fins\"",
+                    "type": "string"
+                },
+                "start_time": {
+                    "description": "StartTime is the start time of the interval",
+                    "type": "string"
+                },
+                "stroke": {
+                    "description": "Stroke is the swimming stroke type like \"freestyle\", \"backstroke\", etc.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.StrokeType"
+                        }
+                    ]
+                },
+                "type": {
+                    "description": "Type is one of the predefined interval types like \"swim\", \"rest\", etc.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.IntervalType"
+                        }
+                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -105,7 +105,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/domain.User"
+                            "$ref": "#/definitions/handler.CreateUserRequest"
                         }
                     }
                 ],
@@ -190,8 +190,8 @@
                 "summary": "Get user by ID",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -232,8 +232,8 @@
                 "summary": "Update an existing user",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -289,8 +289,8 @@
                 "summary": "Delete a user",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "User ID",
+                        "type": "string",
+                        "description": "User ID (UUID)",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -419,7 +419,30 @@
                     "type": "string"
                 },
                 "id": {
-                    "type": "integer"
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.CreateUserRequest": {
+            "type": "object",
+            "required": [
+                "city",
+                "email",
+                "name",
+                "phone"
+            ],
+            "properties": {
+                "city": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -29,7 +29,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/domain.Interval"
+                            "$ref": "#/definitions/handler.CreateIntervalRequest"
                         }
                     }
                 ],
@@ -328,7 +328,7 @@
             "properties": {
                 "activity_id": {
                     "description": "Foreign key to the swim activity/session",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "distance": {
                     "description": "Distance in meters",
@@ -339,7 +339,7 @@
                     "type": "string"
                 },
                 "id": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "notes": {
                     "description": "Optional notes like \"felt strong\", \"used fins\"",
@@ -426,6 +426,55 @@
                 },
                 "phone": {
                     "type": "string"
+                }
+            }
+        },
+        "handler.CreateIntervalRequest": {
+            "type": "object",
+            "required": [
+                "activity_id",
+                "distance",
+                "duration",
+                "start_time",
+                "stroke",
+                "type"
+            ],
+            "properties": {
+                "activity_id": {
+                    "description": "ActivityID is the ID of the associated activity/session",
+                    "type": "string"
+                },
+                "distance": {
+                    "description": "Distance in meters",
+                    "type": "number"
+                },
+                "duration": {
+                    "description": "Duration of the interval in string format, e.g., \"1h30m\"",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Notes are optional remarks such as \"felt strong\", \"used fins\"",
+                    "type": "string"
+                },
+                "start_time": {
+                    "description": "StartTime is the start time of the interval",
+                    "type": "string"
+                },
+                "stroke": {
+                    "description": "Stroke is the swimming stroke type like \"freestyle\", \"backstroke\", etc.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.StrokeType"
+                        }
+                    ]
+                },
+                "type": {
+                    "description": "Type is one of the predefined interval types like \"swim\", \"rest\", etc.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.IntervalType"
+                        }
+                    ]
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -71,11 +71,27 @@ definitions:
       email:
         type: string
       id:
-        type: integer
+        type: string
       name:
         type: string
       phone:
         type: string
+    type: object
+  handler.CreateUserRequest:
+    properties:
+      city:
+        type: string
+      email:
+        type: string
+      name:
+        type: string
+      phone:
+        type: string
+    required:
+    - city
+    - email
+    - name
+    - phone
     type: object
   handler.ErrorResponse:
     properties:
@@ -153,7 +169,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/domain.User'
+          $ref: '#/definitions/handler.CreateUserRequest'
       produces:
       - application/json
       responses:
@@ -178,11 +194,11 @@ paths:
       - application/json
       description: Deletes the user with the specified ID
       parameters:
-      - description: User ID
+      - description: User ID (UUID)
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -209,11 +225,11 @@ paths:
       description: Returns the user with name, email, city, and phone for the specified
         ID
       parameters:
-      - description: User ID
+      - description: User ID (UUID)
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -237,11 +253,11 @@ paths:
       - application/json
       description: Updates the user with the provided ID, name, email, city, and phone
       parameters:
-      - description: User ID
+      - description: User ID (UUID)
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       - description: Updated user data
         in: body
         name: user

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,7 +4,7 @@ definitions:
     properties:
       activity_id:
         description: Foreign key to the swim activity/session
-        type: integer
+        type: string
       distance:
         description: Distance in meters
         type: number
@@ -12,7 +12,7 @@ definitions:
         description: Duration of the interval in string format, e.g., "1h30m"
         type: string
       id:
-        type: integer
+        type: string
       notes:
         description: Optional notes like "felt strong", "used fins"
         type: string
@@ -77,6 +77,41 @@ definitions:
       phone:
         type: string
     type: object
+  handler.CreateIntervalRequest:
+    properties:
+      activity_id:
+        description: ActivityID is the ID of the associated activity/session
+        type: string
+      distance:
+        description: Distance in meters
+        type: number
+      duration:
+        description: Duration of the interval in string format, e.g., "1h30m"
+        type: string
+      notes:
+        description: Notes are optional remarks such as "felt strong", "used fins"
+        type: string
+      start_time:
+        description: StartTime is the start time of the interval
+        type: string
+      stroke:
+        allOf:
+        - $ref: '#/definitions/domain.StrokeType'
+        description: Stroke is the swimming stroke type like "freestyle", "backstroke",
+          etc.
+      type:
+        allOf:
+        - $ref: '#/definitions/domain.IntervalType'
+        description: Type is one of the predefined interval types like "swim", "rest",
+          etc.
+    required:
+    - activity_id
+    - distance
+    - duration
+    - start_time
+    - stroke
+    - type
+    type: object
   handler.CreateUserRequest:
     properties:
       city:
@@ -119,7 +154,7 @@ paths:
         name: interval
         required: true
         schema:
-          $ref: '#/definitions/domain.Interval'
+          $ref: '#/definitions/handler.CreateIntervalRequest'
       produces:
       - application/json
       responses:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gin-gonic/gin v1.10.1
+	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
This pull request introduces a migration from integer-based primary and foreign keys to UUIDs across the codebase, along with updates to the corresponding services, handlers, and tests. Additionally, new request structs for user and interval creation have been added to improve input validation and separation of concerns.

### Database schema updates:
* Updated `users`, `activities`, and `intervals` tables to use `UUID` as primary keys instead of `SERIAL`. Foreign key references were also updated to use `UUID`. (`backend/config/database.go`: [[1]](diffhunk://#diff-caec10ca2974824d5e05fbc70e8fa6ebe4b85df65947ad6e35bb9f1f8dcf3c34L38-R38) [[2]](diffhunk://#diff-caec10ca2974824d5e05fbc70e8fa6ebe4b85df65947ad6e35bb9f1f8dcf3c34L47-R48) [[3]](diffhunk://#diff-caec10ca2974824d5e05fbc70e8fa6ebe4b85df65947ad6e35bb9f1f8dcf3c34L60-R61)

### Domain model changes:
* Modified `User`, `Activity`, and `Interval` structs to use `uuid.UUID` for `ID` and related foreign keys. (`backend/internal/domain/user.go`: [[1]](diffhunk://#diff-128296cb3c6f5e541c0686f433bd55ff6d4ea1ec14d038de71ffd7f11cc50044R3-R8) `backend/internal/domain/activity.go`: [[2]](diffhunk://#diff-e6c073fe0d72aba35f9bf695b41bb8e73ea4179605b22586e7b085661cfc3b6aL19-R24) `backend/internal/domain/interval.go`: [[3]](diffhunk://#diff-0cf118a1d9c8ee1a3d9cb0afd3ab788436bf4b35fa2138e82089f8172e0afb93L52-R56)

### Service layer updates:
* Updated `UserService` and `IntervalService` to use `uuid.UUID` for IDs in method signatures. (`backend/internal/app/user_service.go`: [[1]](diffhunk://#diff-83f7e6f33a9a99bb57b49b7273ccc479d613576be8adcc822a371f21a9c72ea9R6-R16) [[2]](diffhunk://#diff-83f7e6f33a9a99bb57b49b7273ccc479d613576be8adcc822a371f21a9c72ea9L35-R37) [[3]](diffhunk://#diff-83f7e6f33a9a99bb57b49b7273ccc479d613576be8adcc822a371f21a9c72ea9L47-R49)

### Handler improvements:
* Introduced `CreateUserRequest` and `CreateIntervalRequest` structs for request validation. Updated handlers to use these structs and generate UUIDs for new entities. (`backend/internal/handler/input.go`: [[1]](diffhunk://#diff-2755047f7ebeaa086262fa755e838e9da5aa27294a22efe22e565f62d477be59R1-R34) `backend/internal/handler/user_handler.go`: [[2]](diffhunk://#diff-20ae95e2388788aa80fc10b7ee478bce496c47bf83161e4f501011a4283c0e31L28-R53) `backend/internal/handler/interval_handler.go`: [[3]](diffhunk://#diff-9b16c8ebe7f05448fabc0d09994f970931a1413b20bb8fabe991c065e9d27abfL26-R53)

### Test updates:
* Updated all tests to reflect the use of `uuid.UUID` for IDs. Adjusted mock repositories and test cases accordingly. (`backend/internal/app/user_service_test.go`: [[1]](diffhunk://#diff-cc62d53172e3cff1af8433775c88a2391e6c0c0f87898fa0e47951ca25d754d8R8-R21) [[2]](diffhunk://#diff-cc62d53172e3cff1af8433775c88a2391e6c0c0f87898fa0e47951ca25d754d8L31-R33) `backend/internal/handler/interval_handler_test.go`: [[3]](diffhunk://#diff-eb2725d685eaa066ff66905945a4aa9009c3a98f36c908d7c956c9c264ddef69L37-R68) [[4]](diffhunk://#diff-eb2725d685eaa066ff66905945a4aa9009c3a98f36c908d7c956c9c264ddef69L75-R124)

---

Signed-off-by: Ana Livia Ruegger Saldanha [ana.saldanha@usp.br](mailto:ana.saldanha@usp.br)

AI-tool: GitHub Copilot
AI-use: auto generate PR summary (also reviewed and edited by author), review changes